### PR TITLE
Add harvesting-related fixture loading to invoke tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ local_settings.py
 
 .idea/
 .vscode/
+
+docker-compose.override.yml

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -53,6 +53,7 @@ then
     invoke migrations
     invoke prepare
     invoke fixtures
+    invoke nexusfixture
 
     if [ ${IS_CELERY} = "true" ] || [ ${IS_CELERY} = "True" ]
     then
@@ -80,6 +81,7 @@ else
         if [ ${FORCE_REINIT} = "true" ]  || [ ${FORCE_REINIT} = "True" ] || [ ! -e "/mnt/volumes/statics/geonode_init.lock" ]; then
             invoke updategeoip
             invoke fixtures
+            invoke nexusfixture
             invoke monitoringfixture
             invoke initialized
         fi

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -232,19 +232,18 @@ def prepare(ctx):
 @task
 def fixtures(ctx):
     print("**************************fixtures********************************")
-    settings_path = _localsettings()
-    fixture_names = [
-        "sample_admin",
-        "/tmp/default_oauth_apps_docker.json",
-        "/tmp/default_site.json",
-        "/usr/src/nexus/fixtures/initial_data.json",
-        "/usr/src/nexus/fixtures/nexus_harvesters.json",
-    ]
-    for fixture in fixture_names:
-        ctx.run(f"python manage.py loaddata {fixture} --settings={settings_path}", pty=True)
-    ctx.run(f"python manage.py set_all_layers_alternate --settings={settings_path}", pty=True)
-#     ctx.run("python manage.py set_all_layers_metadata -d \
-# --settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py loaddata sample_admin \
+    --settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py loaddata /tmp/default_oauth_apps_docker.json \
+    --settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py loaddata /tmp/default_site.json \
+    --settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py loaddata /usr/src/nexus/fixtures/initial_data.json \
+    --settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py set_all_datasets_alternate \
+    --settings={0}".format(_localsettings()), pty=True)
+    #     ctx.run("python manage.py set_all_datasets_metadata -d \
+    # --settings={0}".format(_localsettings()), pty=True)
 
 
 @task
@@ -270,6 +269,13 @@ def monitoringfixture(ctx):
 --settings={_localsettings()}", pty=True)
     except Exception as e:
         logger.error(f"ERROR installing monitoring fixture: {str(e)}")
+
+
+@task
+def nexusfixture(ctx):
+    print("************************** nexus fixture ********************************")
+    ctx.run("python manage.py loaddata /usr/src/nexus/fixtures/nexus_harvesters.json \
+    --settings={0}".format(_localsettings()), pty=True)
 
 
 @task

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -232,16 +232,17 @@ def prepare(ctx):
 @task
 def fixtures(ctx):
     print("**************************fixtures********************************")
-    ctx.run("python manage.py loaddata sample_admin \
---settings={0}".format(_localsettings()), pty=True)
-    ctx.run("python manage.py loaddata /tmp/default_oauth_apps_docker.json \
---settings={0}".format(_localsettings()), pty=True)
-    ctx.run("python manage.py loaddata /tmp/default_site.json \
---settings={0}".format(_localsettings()), pty=True)
-    ctx.run("python manage.py loaddata /usr/src/nexus/fixtures/initial_data.json \
---settings={0}".format(_localsettings()), pty=True)
-    ctx.run("python manage.py set_all_layers_alternate \
---settings={0}".format(_localsettings()), pty=True)
+    settings_path = _localsettings()
+    fixture_names = [
+        "sample_admin",
+        "/tmp/default_oauth_apps_docker.json",
+        "/tmp/default_site.json",
+        "/usr/src/nexus/fixtures/initial_data.json",
+        "/usr/src/nexus/fixtures/nexus_harvesters.json",
+    ]
+    for fixture in fixture_names:
+        ctx.run(f"python manage.py loaddata {fixture} --settings={settings_path}", pty=True)
+    ctx.run(f"python manage.py set_all_layers_alternate --settings={settings_path}", pty=True)
 #     ctx.run("python manage.py set_all_layers_metadata -d \
 # --settings={0}".format(_localsettings()), pty=True)
 


### PR DESCRIPTION
This PR finalizes #271, making the `fixtures` invoke task also load the harvesting fixtures.

It also adds an entry to  `.gitignore` to ignore files named `docker-compose.override.yml`